### PR TITLE
Correct typos

### DIFF
--- a/using-usql-assemblies/sharing-usql-assemblies-across-accounts.md
+++ b/using-usql-assemblies/sharing-usql-assemblies-across-accounts.md
@@ -3,5 +3,5 @@
 If the assembly you want is in another ADLA account, and you have access to that assembly you can reference it as shown below.
 
 ```
-REFERENCE SYSTEM ASSEMBLY [Account][DBName].[AssemblyName];
+REFERENCE ASSEMBLY [Account][DBName].[AssemblyName];
 ```

--- a/using-usql-assemblies/user-provided-dotnet-assemblies.md
+++ b/using-usql-assemblies/user-provided-dotnet-assemblies.md
@@ -13,7 +13,7 @@ CREATE ASSEMBLY MyDB.OrdersLibAsm
 Below is the standard syntax for referencing an assembly that is in the U-SQL catalog.
  
 ```
-REFERENCE SYSTEM ASSEMBLY [DBName].[AssemblyName];
+REFERENCE ASSEMBLY [DBName].[AssemblyName];
 ```
 
 

--- a/window-functions/percent-rank.md
+++ b/window-functions/percent-rank.md
@@ -1,6 +1,6 @@
 # PERCENT\_RANK
 
-PERCENT\_RANK calculates the relative rank of a row within a group of rows. PERCENT\_RANK is used to evaluate the relative standing of a value within a rowset or partition. The range of values returned by PERCENT\_RANK is greater than 0 and less than or equal to 1. 
+PERCENT\_RANK calculates the relative rank of a row within a group of rows. PERCENT\_RANK is used to evaluate the relative standing of a value within a rowset or partition. The range of values returned by PERCENT\_RANK is in the range `0 <= x <= 1`. 
 
 
 ```


### PR DESCRIPTION
For referencing user assembly, I guess there should not be `SYSTEM` keyword.